### PR TITLE
Add bilingual static website prototype with preview workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 20
       - run: npm test
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
       - id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           node-version: 20
       - run: npm test
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: '.'
       - id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
         with:
           preview: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm test
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # SteelPulse
-SteelPulse is a real-time steel pricing and quotation platform. It provides live price updates for rebar, beams, sheets, pipes, and profiles, along with historical charts and instant quotation requests for suppliers and buyers in the steel market.
+
+SteelPulse is a real-time steel pricing and quotation platform. It provides live price updates for rebar, beams, sheets, pipes,
+and profiles, along with historical charts and instant quotation requests for suppliers and buyers in the steel market.
+
+## Website
+
+The repository contains a minimal static website prototype for the SteelPulse MVP. It includes:
+
+- A product list with sample prices.
+- A price history chart rendered with [Chart.js](https://www.chartjs.org/).
+- A bilingual interface that supports both **English** and **Persian**. Users can switch languages via the buttons on the page, and
+  the layout adjusts for right-to-left text when Persian is selected.
+
+To view the site, open `index.html` in a modern web browser.
+
+## Development
+
+Install Node.js and run:
+
+```
+npm test
+```
+
+No tests are defined yet; the command exists to support CI.
+
+## Continuous Deployment
+
+This repository uses GitHub Actions to deploy the static site to GitHub Pages.
+Every pull request builds the site and provides a preview link in the PR checks.

--- a/data/products.json
+++ b/data/products.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "rebar-12",
+    "name_en": "Rebar 12mm",
+    "name_fa": "میلگرد ۱۲",
+    "price": 750,
+    "last_updated": "2024-05-20T10:00:00Z",
+    "history": [
+      {"date": "2024-05-18", "price": 740},
+      {"date": "2024-05-19", "price": 745},
+      {"date": "2024-05-20", "price": 750}
+    ]
+  },
+  {
+    "id": "beam-20",
+    "name_en": "Beam 20",
+    "name_fa": "تیرآهن ۲۰",
+    "price": 950,
+    "last_updated": "2024-05-20T10:00:00Z",
+    "history": [
+      {"date": "2024-05-18", "price": 940},
+      {"date": "2024-05-19", "price": 945},
+      {"date": "2024-05-20", "price": 950}
+    ]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title id="title">SteelPulse Prices</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <header>
+    <h1 id="header-title">SteelPulse Prices</h1>
+    <div class="lang-switch">
+      <button id="lang-en">English</button>
+      <button id="lang-fa">فارسی</button>
+    </div>
+  </header>
+  <main>
+    <table id="product-table">
+      <thead>
+        <tr>
+          <th data-i18n="product">Product</th>
+          <th data-i18n="price">Price (USD/ton)</th>
+          <th data-i18n="lastUpdated">Last Updated</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <section class="chart-section">
+      <h2 data-i18n="chartTitle">Price History</h2>
+      <canvas id="price-chart" width="400" height="200"></canvas>
+    </section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "steelpulse",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "steelpulse",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "steelpulse",
+  "version": "1.0.0",
+  "description": "SteelPulse is a real-time steel pricing and quotation platform. It provides live price updates for rebar, beams, sheets, pipes, and profiles, along with historical charts and instant quotation requests for suppliers and buyers in the steel market.",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,91 @@
+let products = [];
+let currentLang = 'en';
+let chart;
+
+const translations = {
+  en: {
+    title: 'SteelPulse Prices',
+    product: 'Product',
+    price: 'Price (USD/ton)',
+    lastUpdated: 'Last Updated',
+    chartTitle: 'Price History'
+  },
+  fa: {
+    title: 'قیمت‌های استیل‌پالس',
+    product: 'محصول',
+    price: 'قیمت (دلار/تن)',
+    lastUpdated: 'آخرین بروزرسانی',
+    chartTitle: 'تاریخچه قیمت'
+  }
+};
+
+function setLanguage(lang) {
+  currentLang = lang;
+  document.documentElement.lang = lang === 'en' ? 'en' : 'fa';
+  document.documentElement.dir = lang === 'en' ? 'ltr' : 'rtl';
+  document.getElementById('header-title').textContent = translations[lang].title;
+  document.getElementById('title').textContent = translations[lang].title;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    el.textContent = translations[lang][key];
+  });
+  renderTable();
+  if (products.length > 0) {
+    drawChart(products[0]);
+  }
+}
+
+function renderTable() {
+  const tbody = document.querySelector('#product-table tbody');
+  tbody.innerHTML = '';
+  products.forEach(p => {
+    const tr = document.createElement('tr');
+    const name = currentLang === 'en' ? p.name_en : p.name_fa;
+    const date = new Date(p.last_updated);
+    const formattedDate = date.toLocaleDateString(currentLang === 'en' ? 'en-US' : 'fa-IR');
+    tr.innerHTML = `<td>${name}</td><td>${p.price}</td><td>${formattedDate}</td>`;
+    tr.addEventListener('click', () => drawChart(p));
+    tbody.appendChild(tr);
+  });
+}
+
+function drawChart(product) {
+  const ctx = document.getElementById('price-chart').getContext('2d');
+  const labels = product.history.map(h => h.date);
+  const data = product.history.map(h => h.price);
+  if (chart) chart.destroy();
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: currentLang === 'en' ? product.name_en : product.name_fa,
+        data,
+        borderColor: '#0074D9',
+        fill: false
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        title: {
+          display: true,
+          text: translations[currentLang].chartTitle
+        }
+      }
+    }
+  });
+}
+
+fetch('data/products.json')
+  .then(r => r.json())
+  .then(data => {
+    products = data;
+    renderTable();
+    drawChart(products[0]);
+  });
+
+document.getElementById('lang-en').addEventListener('click', () => setLanguage('en'));
+document.getElementById('lang-fa').addEventListener('click', () => setLanguage('fa'));
+
+document.addEventListener('DOMContentLoaded', () => setLanguage(currentLang));

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,37 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.lang-switch button {
+  margin-left: 10px;
+  padding: 5px 10px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: center;
+}
+
+tr:hover {
+  background-color: #f5f5f5;
+  cursor: pointer;
+}
+
+.chart-section {
+  max-width: 600px;
+}


### PR DESCRIPTION
## Summary
- Add static HTML/JS/CSS prototype for SteelPulse with product list and price chart
- Implement language switcher supporting English and Persian with RTL layout
- Introduce GitHub Actions workflow that deploys site to GitHub Pages with PR previews and minimal Node test script
- Document development and CI setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f6381e37083238953bd36347f21a6